### PR TITLE
Add aligned-spin conditions to PhenomPv2 angle calculations

### DIFF
--- a/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
+++ b/src/ripplegw/waveforms/IMRPhenomPv2_utils.py
@@ -94,7 +94,7 @@ def convert_spins(
 
     thetaJ_sf = jnp.arccos(J0z_sf / J0)
 
-    no_inplane_J0 = jnp.abs(J0x_sf) < MAX_TOL_ATAN and jnp.abs(J0y_sf) < MAX_TOL_ATAN
+    no_inplane_J0 = (jnp.abs(J0x_sf) < MAX_TOL_ATAN) & (jnp.abs(J0y_sf) < MAX_TOL_ATAN)
     phiJ_sf = jnp.where(
         no_inplane_J0,
         jnp.pi / 2.0 - phiRef,  # This is the aligned-spin case
@@ -124,7 +124,7 @@ def convert_spins(
     tmp_x, tmp_y, tmp_z = ROTATEY(-thetaJ_sf, tmp_x, tmp_y, tmp_z)
     tmp_x, tmp_y, tmp_z = ROTATEZ(kappa, tmp_x, tmp_y, tmp_z)
 
-    no_inplane_LN = jnp.abs(tmp_x) < MAX_TOL_ATAN and jnp.abs(tmp_y) < MAX_TOL_ATAN
+    no_inplane_LN = (jnp.abs(tmp_x) < MAX_TOL_ATAN) & (jnp.abs(tmp_y) < MAX_TOL_ATAN)
     alpha0 = jnp.where(
         no_inplane_LN,
         jnp.pi,  # This is the aligned-spin case


### PR DESCRIPTION
This PR adds back the special treatments for two angles in the aligned-spin case implemented in `LALSimulation` for `PhenomPv2`. 
These changes do not affect the behaviour of `PhenomPv2` in most cases, and only in aligned-spin cases. 

Specifically, they are here in `LALSimulation`:
* `phiJ_sf`: [this line](https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_i_m_r_phenom_p_8c_source.html#l00372), and
* `alpha0`: [this line](https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_i_m_r_phenom_p_8c_source.html#l00410)

This PR also fixes the apparent $\pi / 2$ phase shift mentioned in https://github.com/tedwards2412/ripple/issues/35.

This PR is duplicated from https://github.com/tedwards2412/ripple/pull/36