### PR TITLE
fix: Fix the bugs in IMRPhenomXPHM and IMRPhenomXHM

### DIFF
--- a/src/ripplegw/waveforms/IMRPhenomXHM.py
+++ b/src/ripplegw/waveforms/IMRPhenomXHM.py
@@ -13,7 +13,7 @@ The 22-mode reuses ripple's existing IMRPhenomXAS.py (Phase + Amp functions).
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Any, Tuple
 import jax
 import jax.numpy as jnp
 from jax import Array
@@ -31,6 +31,8 @@ from .spherical_harmonics import (
     compute_sminus2_l3,
     compute_sminus2_l4,
 )
+
+Real = Any
 
 # ---------------------------------------------------------------------------
 # Section 1: QNM fits
@@ -454,7 +456,7 @@ class XHMWaveformStruct:
     etaEMR: float  # = 0.05
 
 
-def build_pWF22(m1: float, m2: float, chi1z: float, chi2z: float, f_ref: float) -> dict:
+def build_pWF22(m1: Real, m2: Real, chi1z: Real, chi2z: Real, f_ref: float) -> dict:
     """
     Build the 22-mode waveform parameter dict needed by XHM functions.
 
@@ -487,8 +489,6 @@ def build_pWF22(m1: float, m2: float, chi1z: float, chi2z: float, f_ref: float) 
 
     # Recompute afinal and Erad (same formula as IMRPhenomX_utils.get_cutoff_fMs)
     # but also exposed here for XHM use.
-    S2 = S * S
-    S3 = S2 * S
     STotR2 = STotR * STotR
     STotR3 = STotR2 * STotR
     dchi2 = dchi * dchi
@@ -585,8 +585,11 @@ def build_pWF22(m1: float, m2: float, chi1z: float, chi2z: float, f_ref: float) 
     )
 
     chi_eff = mm1 * chi1z + mm2 * chi2z
-    # chiPN = chi_eff - (38/113)*eta*(chi1+chi2)  [LAL chiPNHat, no denominator]
-    chiPN = chi_eff - (38.0 / 113.0) * eta * (chi1z + chi2z)
+    # chiPN = LAL's chiPNHat: (chi_eff - (38/113)*eta*(chi1+chi2)) / (1 - 76*eta/113)
+    # Source: XLALSimIMRPhenomXchiPNHat in LALSimIMRPhenomXUtilities.c
+    chiPN = (chi_eff - (38.0 / 113.0) * eta * (chi1z + chi2z)) / (
+        1.0 - 76.0 * eta / 113.0
+    )
     # Amplitude normalization: sqrt(2*eta/3) * pi^(-1/6)
     # Source: LALSimIMRPhenomX_internals.c line 610:
     #   wf->ampNorm = sqrt(2.0/3.0) * sqrt(wf->eta) * powers_of_lalpi.m_one_sixth;
@@ -722,7 +725,7 @@ def XLALSimIMRPhenomXLinb(eta: float, STotR: float, dchi: float, delta: float) -
     return noSpin + eqSpin + uneqSpin
 
 
-def XLALSimIMRPhenomXPsi4ToStrain(eta: float, STotR: float, dchi: float) -> float:
+def XLALSimIMRPhenomXPsi4ToStrain(eta: Real, STotR: Real, dchi: Real) -> Real:
     """
     Psi4-to-strain conversion factor for the time-shift.
 
@@ -801,7 +804,7 @@ def IMRPhenomX_TimeShift_22(pWF22: dict) -> float:
 # ---------------------------------------------------------------------------
 
 
-def _xhm_insp_phase_LambdaPN(modeTag: int, eta: float) -> float:
+def _xhm_insp_phase_LambdaPN(modeTag: int, eta: Real) -> Real:
     """
     Leading-order PN phase correction for each mode's inspiral ansatz.
 
@@ -862,6 +865,7 @@ def _xhm_inter_phase_colloc_pts(
     eta4 = eta3 * eta
     eta5 = eta4 * eta
     eta6 = eta5 * eta
+    eta7 = eta6 * eta
     S2 = S * S
     S3 = S2 * S
     S4 = S3 * S
@@ -1355,15 +1359,15 @@ def _xhm_inter_phase_colloc_pts(
 
 
 def _xhm_inter_phase_ansatz_int(
-    Mf: Array,
-    c0: float,
-    c1: float,
-    c2: float,
-    c4: float,
-    cL: float,
-    fRD: float,
-    fDA: float,
-) -> Array:
+    Mf: Real,
+    c0: Real,
+    c1: Real,
+    c2: Real,
+    c4: Real,
+    cL: Real,
+    fRD: Real,
+    fDA: Real,
+) -> Real:
     """
     Integral of intermediate phase ansatz (non-32 modes):
       phi = c0*f + c1*log(f) - c2/f - c4/(3*f^3) + cL*atan((f-fRD)/fDA)
@@ -1381,15 +1385,15 @@ def _xhm_inter_phase_ansatz_int(
 
 
 def _xhm_inter_phase_ansatz_deriv(
-    Mf: Array,
-    c0: float,
-    c1: float,
-    c2: float,
-    c4: float,
-    cL: float,
-    fRD: float,
-    fDA: float,
-) -> Array:
+    Mf: Real,
+    c0: Real,
+    c1: Real,
+    c2: Real,
+    c4: Real,
+    cL: Real,
+    fRD: Real,
+    fDA: Real,
+) -> Real:
     """
     Derivative of intermediate phase ansatz (non-32 modes):
       dphi = c0 + c1/f + c2/f^2 + c4/f^4 + cL*fDA/(fDA^2+(f-fRD)^2)
@@ -1491,8 +1495,8 @@ def _xhm_rd_phase_alphaL_22fit(
 
 
 def _xhm_rd_phase_ansatz_int(
-    Mf: Array, alpha0: float, alpha2: float, alphaL: float, fRD: float, fDA: float
-) -> Array:
+    Mf: Real, alpha0: Real, alpha2: Real, alphaL: Real, fRD: Real, fDA: Real
+) -> Real:
     """
     Integral of ringdown phase ansatz (alpha0 is effectively C1RD from continuity):
       phi = alpha0*f - fRD^2*alpha2/f + alphaL*atan((f-fRD)/fDA)
@@ -1503,8 +1507,8 @@ def _xhm_rd_phase_ansatz_int(
 
 
 def _xhm_rd_phase_ansatz_deriv(
-    Mf: Array, alpha0: float, alpha2: float, alphaL: float, fRD: float, fDA: float
-) -> Array:
+    Mf: Real, alpha0: Real, alpha2: Real, alphaL: Real, fRD: Real, fDA: Real
+) -> Real:
     """
     Derivative of ringdown phase ansatz:
       dphi = alpha0 + fRD^2*alpha2/f^2 + alphaL*fDA/(fDA^2+(f-fRD)^2)
@@ -1520,16 +1524,16 @@ def _xhm_rd_phase_ansatz_deriv(
 
 
 def _xhm_inter_phase_ansatz_int_6(
-    Mf: float,
-    c0: float,
-    cL: float,
-    c1: float,
-    c2: float,
-    c4: float,
-    c3: float,
-    fRD: float,
-    fDA: float,
-) -> float:
+    Mf: Real,
+    c0: Real,
+    cL: Real,
+    c1: Real,
+    c2: Real,
+    c4: Real,
+    c3: Real,
+    fRD: Real,
+    fDA: Real,
+) -> Real:
     """6-coefficient intermediate phase integral (used for 32 mode with mixing).
     Ansatz: c0 + cL*L + c1/f + c2/f^2 + c4/f^4 + c3/f^3  (derivative)
     Integral: c0*f + cL*atan(...) + c1*log(f) - c2/f - c4/(3f^3) - c3/(2f^2)
@@ -1545,16 +1549,16 @@ def _xhm_inter_phase_ansatz_int_6(
 
 
 def _xhm_inter_phase_ansatz_deriv_6(
-    Mf: float,
-    c0: float,
-    cL: float,
-    c1: float,
-    c2: float,
-    c4: float,
-    c3: float,
-    fRD: float,
-    fDA: float,
-) -> float:
+    Mf: Real,
+    c0: Real,
+    cL: Real,
+    c1: Real,
+    c2: Real,
+    c4: Real,
+    c3: Real,
+    fRD: Real,
+    fDA: Real,
+) -> Real:
     """6-coefficient intermediate phase derivative (used for 32 mode with mixing)."""
     return (
         c0
@@ -1567,15 +1571,15 @@ def _xhm_inter_phase_ansatz_deriv_6(
 
 
 def _xhm_rd_phase_spheroidal_int(
-    Mf: float,
-    alpha0_S: float,
-    alphaL_S: float,
-    alpha2_S: float,
-    alpha4_S: float,
-    phi0_S: float,
-    fRING: float,
-    fDAMP: float,
-) -> float:
+    Mf: Real,
+    alpha0_S: Real,
+    alphaL_S: Real,
+    alpha2_S: Real,
+    alpha4_S: Real,
+    phi0_S: Real,
+    fRING: Real,
+    fDAMP: Real,
+) -> Real:
     """Spheroidal RD phase integral (version 122019).
     phi(f) = phi0_S + alpha0_S*f - alpha2_S/f - alpha4_S/(3*f^3) + alphaL_S*atan(...)
     Source: IMRPhenomXHM_RD_Phase_AnsatzInt MixingOn=1, LALSimIMRPhenomXHM_ringdown.c.
@@ -1801,7 +1805,7 @@ def _xhm_rd_phase_32_collocpts(
 
 def _xhm_rd_phase_32_spheroidal_time_shift(
     eta: float, STotR: float, dchi: float, delta: float
-) -> float:
+) -> Real:
     """Time shift fit for 32-mode spheroidal phase (version 122019).
     Source: IMRPhenomXHM_RD_Phase_32_SpheroidalTimeShift, LALSimIMRPhenomXHM_ringdown.c.
     """
@@ -1857,7 +1861,7 @@ def _xhm_rd_phase_32_spheroidal_time_shift(
 
 def _xhm_rd_phase_32_spheroidal_phase_shift(
     eta: float, STotR: float, dchi: float, delta: float, chi1L: float, chi2L: float
-) -> float:
+) -> Real:
     """Phase shift fit for 32-mode spheroidal phase (version 122019).
     Source: IMRPhenomXHM_RD_Phase_32_SpheroidalPhaseShift, LALSimIMRPhenomXHM_ringdown.c.
     """
@@ -2116,7 +2120,7 @@ def _xhm_s2s_complex(
     fAmpRDfalloff32: float,
     rdaux_poly_c: Array,
     rdaux_falloff_amp: float,
-    rdaux_falloff_slope: float,
+    rdaux_falloff_slope: Real,
 ) -> complex:
     """SpheroidalToSpherical for version 122022, mode 32 (RingdownAmpVersion=1).
 
@@ -2127,7 +2131,7 @@ def _xhm_s2s_complex(
     wf22R = amp22 * ampNorm * Mf^(-7/6) * exp(i*phi22)  (v1: scaled)
     Returns |S2S| in full-strain units.
     """
-    amp22, _ = get_mergerringdown_Amp(Mf, theta, amp_coeffs_22)
+    amp22, _ = get_mergerringdown_Amp(Mf, theta, amp_coeffs_22)  # pyright: ignore[reportArgumentType]
     phi22 = IMRPhenomXAS_Phase(Mf / M_s, theta, phase_coeffs) + t0 * Mf + phifRef
     wf22R = amp22 * ampNorm * Mf ** (-7.0 / 6.0) * jnp.exp(1j * phi22)
 
@@ -2161,7 +2165,7 @@ def _compute_32_hlm(
     pWF22: dict,
     t0: float,
     phifRef: float,
-    phi0: float,
+    phi0: Real,
 ) -> Array:
     """Evaluate complex h_{3,2}(f) with spheroidal mode mixing (version 122019).
 
@@ -2187,7 +2191,6 @@ def _compute_32_hlm(
     fRING22 = pWF22["fRING22"]
     fDAMP22 = pWF22["fDAMP22"]
 
-    ell = pWFHM.ell
     emm = pWFHM.emm
     fRING32 = pWFHM.fRING
     fDAMP32 = pWFHM.fDAMP
@@ -2637,28 +2640,28 @@ class XHMPhaseCoefficients:
     """
 
     # Inspiral: deviation from 22-mode rescaling
-    ins_c0: float
-    ins_c1: float
-    ins_c2: float
-    ins_c4: float
-    ins_C1INSP: float  # continuity shift for dphi at fMatchIN
-    ins_CINSP: float  # continuity shift for phi at fMatchIN
+    ins_c0: Real
+    ins_c1: Real
+    ins_c2: Real
+    ins_c4: Real
+    ins_C1INSP: Real  # continuity shift for dphi at fMatchIN
+    ins_CINSP: Real  # continuity shift for phi at fMatchIN
 
     # Intermediate: 5 polynomial coefficients [c0, c1, c2, c4, cL]
-    inter_c0: float
-    inter_c1: float
-    inter_c2: float
-    inter_c4: float
-    inter_cL: float
+    inter_c0: Real
+    inter_c1: Real
+    inter_c2: Real
+    inter_c4: Real
+    inter_cL: Real
 
     # Ringdown: alpha2, alphaL (alpha0 = C1RD), CRD
-    rd_alpha2: float
-    rd_alphaL: float
-    rd_C1RD: float
-    rd_CRD: float
+    rd_alpha2: Real
+    rd_alphaL: Real
+    rd_C1RD: Real
+    rd_CRD: Real
 
     # Phase normalization
-    deltaphiLM: float
+    deltaphiLM: Real
 
     # Boundary frequencies
     fMatchIN: float
@@ -2736,6 +2739,22 @@ def xhm_get_phase_coefficients(
         _xhm_inter_phase_colloc_pts(modeInt, eta, STotR, dchi, delta, chi1L, chi2L)
         + DeltaT
     )
+
+    # LAL applies an extra high-spin 21 safeguard before choosing the 5/6
+    # intermediate collocation points: it rewrites the first two derivative
+    # values using finite differences of the full 22-mode phase derivative.
+    if pWFHM.modeTag == 21:
+        two_over_m = 2.0 / emm
+
+        def dphi22_at(Mf_):
+            return jax.grad(IMRPhenomXAS_Phase)(Mf_ / M_s, theta, phase_coeffs) / M_s
+
+        insp_vals = jnp.array([dphi22_at(two_over_m * all_freqs[i]) for i in range(3)])
+        diff12 = insp_vals[0] - insp_vals[1]
+        diff23 = insp_vals[1] - insp_vals[2]
+        all_vals_21hs = all_vals.at[1].set(all_vals[2] + diff23)
+        all_vals_21hs = all_vals_21hs.at[0].set(all_vals_21hs[1] + diff12)
+        all_vals = jnp.where(STotR >= 0.8, all_vals_21hs, all_vals)
 
     # -----------------------------------------------------------------------
     # Step 3: Ringdown: alpha2, alphaL (with wlm rescaling)
@@ -2948,7 +2967,6 @@ def xhm_phase_noModeMixing(
     """
     emm = pWFHM.emm
     modeTag = pWFHM.modeTag
-    M_s = pWF22["M_s"]
     theta = pWF22["theta"]
     phase_coeffs = pWF22["phase_coeffs"]
     eta = pWF22["eta"]
@@ -3330,8 +3348,8 @@ def _xhm_rd_rescaled(
 
 
 def _xhm_rd_rescaled_v1(
-    f: float, alambda: float, lambda_: float, sigma: float, fRING: float, fDAMP: float
-) -> float:
+    f: Real, alambda: Real, lambda_: Real, sigma: Real, fRING: Real, fDAMP: Real
+) -> Real:
     """
     RD amplitude ansatz case 1 (122022 for mode 32).
     Returns: fDAMP*|alambda| * exp(-lambda*(f-fRING)/(fDAMP*sigma)) / ((f-fRING)^2+(fDAMP*sigma)^2)
@@ -4139,7 +4157,6 @@ def _xhm_inter_amp_colloc_pts(
     eta6 = eta1 * eta5
     S1 = STotR
     S2 = S1 * S1
-    S3 = S1 * S2
     chidiff1 = dchi_half
     chidiff2 = chidiff1 * chidiff1
     sqroot = jnp.sqrt(eta)
@@ -4918,7 +4935,6 @@ def _xhm_inter_amp_colloc_pts(
     else:
         S1 = chiPN
         S2 = S1 * S1
-        S3 = S1 * S2
         int1 = (
             eta1
             * (
@@ -5149,7 +5165,6 @@ def _xhm_rd_amp_fit_coeffs(
     eta4 = eta1 * eta3
     eta5 = eta1 * eta4
     eta6 = eta1 * eta5
-    eta7 = eta1 * eta6
     S1 = STotR
     S2 = S1 * S1
     chidiff1 = dchi_half
@@ -6286,7 +6301,7 @@ def _xhm_rd_amp_rdaux_pts(
     return rdaux1, rdaux2
 
 
-def _xhm_fAmpMatchIN(pWFHM: "XHMWaveformStruct", pWF22: dict) -> float:
+def _xhm_fAmpMatchIN(pWFHM: "XHMWaveformStruct", pWF22: dict) -> Real:
     """Inspiral-to-intermediate cutoff frequency (version 122022)."""
     eta = pWF22["eta"]
     chi1 = pWF22["chi1L"]
@@ -6337,29 +6352,29 @@ class XHMAmpCoefficients:
     """
 
     # PN global factor: (2/emm)^(-7/6) * prefactor[modeInt]
-    PNglobalfactor: float
+    PNglobalfactor: Real
     # Complex PN polynomial coefficients
     pn_coeffs: (
         tuple  # (pnInit, pnOneTh, pnTwoTh, pnThreeTh, pnFourTh, pnFiveTh, pnSixTh)
     )
     # Inspiral pseudo-PN coefficients (rho1, rho2, rho3)
-    ins_rho1: float
-    ins_rho2: float
-    ins_rho3: float
+    ins_rho1: Real
+    ins_rho2: Real
+    ins_rho3: Real
     # Inspiral cutoff (= fAmpMatchIN after veto, for pseudo-PN normalization)
-    fAmpMatchIN: float
+    fAmpMatchIN: Real
     # Intermediate polynomial coefficients (122022 direct: c0..c7, shape (8,))
     inter_c: Array
     # Ringdown parameters
-    ring_alambda: float
-    ring_lambda: float
-    ring_sigma: float
+    ring_alambda: Real
+    ring_lambda: Real
+    ring_sigma: Real
     # Boundary frequencies
-    fAmpMatchIM: float
-    fRING: float
-    fDAMP: float
+    fAmpMatchIM: Real
+    fRING: Real
+    fDAMP: Real
     # Amplitude normalization (sqrt(2*eta/3)*pi^(-1/6), from pWF22->ampNorm)
-    ampNorm: float
+    ampNorm: Real
     # SPA coefficients for mode (2,1) inspiral; None for other modes
     spa_coeffs: object = None
 
@@ -7462,7 +7477,7 @@ def XLALSimIMRPhenomXHMEvaluateOnehlmMode(
     pAmp: XHMAmpCoefficients,
     pWF22: dict,
     t0: float,
-    phi0: float,
+    phi0: Real,
 ) -> Array:
     """
     Evaluate complex hlm for one mode at all frequencies.
@@ -7474,8 +7489,6 @@ def XLALSimIMRPhenomXHMEvaluateOnehlmMode(
     Source: IMRPhenomXHMEvaluateOnehlmMode in LALSimIMRPhenomXHM.c.
     """
     emm = pWFHM.emm
-    Mf_ref = pWF22["Mf_ref"]
-
     # Phase
     if pWFHM.MixingOn:
         phase_lm = xhm_phase_ModeMixing(freqs_geom, pPhase, pWFHM, pWF22, t0)
@@ -7499,7 +7512,7 @@ def XLALSimIMRPhenomXHMEvaluateOnehlmMode(
 def XLALSimIMRPhenomXHMGethlmModes(
     freqs_geom: Array,
     pWF22: dict,
-    phi0: float,
+    phi0: Real,
     ell_mm_pairs: list,
 ) -> dict:
     """
@@ -7530,8 +7543,6 @@ def XLALSimIMRPhenomXHMGethlmModes(
     theta = pWF22["theta"]
     phase_coeffs = pWF22["phase_coeffs"]
     Mf_ref = pWF22["Mf_ref"]
-    eta = pWF22["eta"]
-
     # Step 1: time shift for 22 mode
     t0 = IMRPhenomX_TimeShift_22(pWF22)
 

--- a/src/ripplegw/waveforms/IMRPhenomXPHM.py
+++ b/src/ripplegw/waveforms/IMRPhenomXPHM.py
@@ -22,7 +22,6 @@ from .IMRPhenomD import Phase as IMRPhenomD_Phase
 from .IMRPhenomD import IMRPhenDAmplitude_NoCut
 from .IMRPhenomD import get_IIb_raw_phase
 from .IMRPhenomPv2_utils import FinalSpin0815
-from .IMRPhenomXHM import build_pWF22, XLALSimIMRPhenomXHMGethlmModes
 
 
 # Phase shift due to leading order complex amplitude
@@ -62,19 +61,24 @@ def generate_xphm(
     _ell_mm_pairs = [(2, 1), (2, 2), (3, 2), (3, 3), (4, 4)]
     _mode_array = jnp.array([[2, 1], [2, 2], [3, 2], [3, 3], [4, 4]], dtype=jnp.int32)
 
-    # Build 22-mode waveform parameter struct and geometric frequency array.
-    M_s = Mtot * MTSUN  # total mass in seconds
-    freqs_geom = frequency_array * M_s  # dimensionless geometric frequencies
-
-    # pWF22 uses only aligned-spin components chi1z, chi2z for t0 and phase.
-    pWF22 = build_pWF22(mass_1, mass_2, chi1z, chi2z, reference_frequency)
-
-    # Generate XHM modes with phi0=0 (same convention as old HM call:
-    # phiRef enters through twistup only, not through mode generation).
-    hlm_dict = XLALSimIMRPhenomXHMGethlmModes(freqs_geom, pWF22, 0.0, _ell_mm_pairs)
-
-    # Stack into (5, n_freqs) array in mode order [(2,1),(2,2),(3,2),(3,3),(4,4)]
-    hlm = jnp.stack([hlm_dict[lm] for lm in _ell_mm_pairs])
+    # Build the co-precessing seed used by LAL's current XPHM validation path.
+    # The repo's LAL-side helpers explicitly enable TwistPhenomHM=1, which twists
+    # up the legacy PhenomHM modes rather than the XHM modes.
+    hlm = XLALSimIMRPhenomHMGethlmModes(
+        frequency_array,
+        mass_1 * MSUN,
+        mass_2 * MSUN,
+        chi1x,
+        chi1y,
+        chi1z,
+        chi2x,
+        chi2y,
+        chi2z,
+        0.0,
+        0.0,
+        reference_frequency,
+        {"ModeArray": _mode_array},
+    )
 
     ells = _mode_array[:, 0]
     minus1l = jnp.where(ells % 2 != 0, -1, 1)

--- a/src/ripplegw/waveforms/initialize_MSA_system.py
+++ b/src/ripplegw/waveforms/initialize_MSA_system.py
@@ -18,6 +18,7 @@ def IMRPhenomX_Initialize_MSA_System(
     chi2z,
     reference_frequency,
     pflag=223,
+    expansion_order=5,
 ):
     """
     First initialize the system of variables needed for Chatziioannou et al, PRD, 88, 063011, (2013), arXiv:1307.4418:
@@ -256,7 +257,6 @@ def IMRPhenomX_Initialize_MSA_System(
             eta,
         )
     )
-    """
     a5 = eta * (
         domegadt_constants_NS[7]
         + eta * (domegadt_constants_NS[8])
@@ -268,7 +268,6 @@ def IMRPhenomX_Initialize_MSA_System(
             q,
         )
     )
-    """
 
     # Useful powers of a_0
     a0_2 = a0 * a0
@@ -281,7 +280,7 @@ def IMRPhenomX_Initialize_MSA_System(
     g2 = -(a2 / a0_2)
     g3 = -(a3 / a0_2)
     g4 = -(a4 * a0 - a2_2) / a0_3
-    # g5 = 0.0  # -(a5 * a0 - 2.0 * a3 * a2) / a0_3
+    g5 = -(a5 * a0 - 2.0 * a3 * a2) / a0_3
 
     # Useful powers of delta
     delta = delta_qq
@@ -437,13 +436,11 @@ def IMRPhenomX_Initialize_MSA_System(
     ) - adD * fdD * fdD
 
     # Eq. D15 in PRD, 95, 104004, (2017), arXiv:1703.03967
-    """
     Omegaz5 = (
         (cdD - adDfdD + adDhdD_2) * fdD * (Seff + 2.0 * hdD)
         - (cdD + adDhdD_2 - 2.0 * adDfdD) * hdD_2 * (Seff + hdD)
         - adDfdD * fdD * hdD
     )
-    """
 
     # Coefficients of Eq. 65, as defined in Equations D16 - D21 of PRD, 95, 104004, (2017), arXiv:1703.03967
     Omegaz0_coeff = 3.0 * g0 * Omegaz0
@@ -451,7 +448,9 @@ def IMRPhenomX_Initialize_MSA_System(
     Omegaz2_coeff = 3.0 * (g0 * Omegaz2 + g2 * Omegaz0)
     Omegaz3_coeff = 3.0 * (g0 * Omegaz3 + g2 * Omegaz1 + g3 * Omegaz0)
     Omegaz4_coeff = 3.0 * (g0 * Omegaz4 + g2 * Omegaz2 + g3 * Omegaz1 + g4 * Omegaz0)
-    Omegaz5_coeff = 0  # 3.0 * (g0 * Omegaz5 + g2 * Omegaz3 + g3 * Omegaz2 + g4 * Omegaz1 + g5 * Omegaz0)
+    Omegaz5_coeff = 3.0 * (
+        g0 * Omegaz5 + g2 * Omegaz3 + g3 * Omegaz2 + g4 * Omegaz1 + g5 * Omegaz0
+    )
 
     # Coefficients of zeta: in Appendix E of PRD, 95, 104004, (2017), arXiv:1703.03967
     c1oveta2 = c_1 / eta2
@@ -460,7 +459,7 @@ def IMRPhenomX_Initialize_MSA_System(
     Omegazeta2 = Omegaz2 + Omegaz1 * c1oveta2
     Omegazeta3 = Omegaz3 + Omegaz2 * c1oveta2 + gdD
     Omegazeta4 = Omegaz4 + Omegaz3 * c1oveta2 - gdD * Seff - gdD * hdD
-    # Omegazeta5 = Omegaz5 + Omegaz4 * c1oveta2 + gdD * hdD * Seff + gdD * (hdD_2 - fdD)
+    Omegazeta5 = Omegaz5 + Omegaz4 * c1oveta2 + gdD * hdD * Seff + gdD * (hdD_2 - fdD)
 
     Omegazeta0_coeff = -g0 * Omegazeta0
     Omegazeta1_coeff = -1.5 * g0 * Omegazeta1
@@ -469,7 +468,57 @@ def IMRPhenomX_Initialize_MSA_System(
     Omegazeta4_coeff = 3.0 * (
         g0 * Omegazeta4 + g2 * Omegazeta2 + g3 * Omegazeta1 + g4 * Omegazeta0
     )
-    Omegazeta5_coeff = 0.0  # 1.5 * (g0 * Omegazeta5 + g2 * Omegazeta3 + g3 * Omegazeta2 + g4 * Omegazeta1 + g5 * Omegazeta0)
+    Omegazeta5_coeff = 1.5 * (
+        g0 * Omegazeta5
+        + g2 * Omegazeta3
+        + g3 * Omegazeta2
+        + g4 * Omegazeta1
+        + g5 * Omegazeta0
+    )
+
+    # LAL's default PhenomXPExpansionOrder=5 truncates the 5th-order correction
+    # coefficients before phiz_0/zeta_0 are initialized.
+    if expansion_order == -1:
+        pass
+    elif expansion_order == 1:
+        Omegaz1_coeff = 0.0
+        Omegazeta1_coeff = 0.0
+        Omegaz2_coeff = 0.0
+        Omegazeta2_coeff = 0.0
+        Omegaz3_coeff = 0.0
+        Omegazeta3_coeff = 0.0
+        Omegaz4_coeff = 0.0
+        Omegazeta4_coeff = 0.0
+        Omegaz5_coeff = 0.0
+        Omegazeta5_coeff = 0.0
+    elif expansion_order == 2:
+        Omegaz2_coeff = 0.0
+        Omegazeta2_coeff = 0.0
+        Omegaz3_coeff = 0.0
+        Omegazeta3_coeff = 0.0
+        Omegaz4_coeff = 0.0
+        Omegazeta4_coeff = 0.0
+        Omegaz5_coeff = 0.0
+        Omegazeta5_coeff = 0.0
+    elif expansion_order == 3:
+        Omegaz3_coeff = 0.0
+        Omegazeta3_coeff = 0.0
+        Omegaz4_coeff = 0.0
+        Omegazeta4_coeff = 0.0
+        Omegaz5_coeff = 0.0
+        Omegazeta5_coeff = 0.0
+    elif expansion_order == 4:
+        Omegaz4_coeff = 0.0
+        Omegazeta4_coeff = 0.0
+        Omegaz5_coeff = 0.0
+        Omegazeta5_coeff = 0.0
+    elif expansion_order == 5:
+        Omegaz5_coeff = 0.0
+        Omegazeta5_coeff = 0.0
+    else:
+        raise ValueError(
+            f"Expansion order for MSA corrections = {expansion_order} not recognized."
+        )
 
     # Get psi0 term
     psi0 = compute_psi0(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,10 @@ This module provides fixtures for common test setup, including default
 frequency grid parameters.
 """
 
+import jax
 import pytest
+
+jax.config.update("jax_enable_x64", True)
 
 from tests.utils import get_freqs
 

--- a/tests/cross_validation/test_lal_xhm_amplitude.py
+++ b/tests/cross_validation/test_lal_xhm_amplitude.py
@@ -1,0 +1,110 @@
+"""Layer 3: per-mode amplitude vs lalsim.SimIMRPhenomXHMAmplitude.
+
+For each mode the test computes the relative amplitude error in three
+disjoint frequency bands (inspiral / intermediate / ringdown) so that a
+failing region pinpoints which polynomial fit is wrong.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tests.cross_validation.xhm_helpers import (
+    LAL_AVAILABLE,
+    FIDUCIAL_PARAMS,
+    NON_22_MODES,
+    lal_xhm_amplitude,
+    make_freq_grid,
+    region_masks,
+    relative_amp_error,
+    ripple_pwf22,
+)
+
+from ripplegw.waveforms.IMRPhenomXHM import (
+    xhm_set_waveform_variables,
+    xhm_get_amp_coefficients,
+    xhm_amp_noModeMixing,
+    _compute_32_hlm,
+)
+
+pytestmark = pytest.mark.skipif(
+    not LAL_AVAILABLE, reason="LALSuite required for cross-validation tests"
+)
+
+
+# Per-region tolerances on the relative amplitude error.
+# The 22 mode dominates the SNR so its tolerance must be tightest;
+# subdominant modes are allowed proportionally looser bands.
+# Values calibrated so that, when satisfied, the 1e-6 mismatch budget
+# is comfortably met after the noise-weighted integral.
+_TOL = {
+    # (2,2) goes through XAS path (validated by IMRPhenomXAS tests).
+    (2, 1): dict(inspiral=1e-10, intermediate=1e-10, ringdown=1e-10),
+    (3, 3): dict(inspiral=1e-10, intermediate=1e-10, ringdown=1e-10),
+    (3, 2): dict(inspiral=1e-9,  intermediate=1e-9,  ringdown=1e-9),
+    (4, 4): dict(inspiral=1e-10, intermediate=1e-10, ringdown=1e-10),
+}
+
+
+def _ripple_amp_only(freqs_hz, ell, m, params=FIDUCIAL_PARAMS):
+    """Per-mode |Amp_lm(f)| from ripple, distance-normalised the same
+    way as LAL's SimIMRPhenomXHMAmplitude.
+
+    For (3,2) we extract the amplitude from the magnitude of
+    `_compute_32_hlm` (which entangles the mixing).  For all other
+    modes the path is `xhm_amp_noModeMixing`.
+    """
+    pWF22 = ripple_pwf22(params)
+    M_s = pWF22["M_s"]
+    freqs_geom = jnp.array(freqs_hz) * M_s
+    pWFHM = xhm_set_waveform_variables(int(ell), int(m), pWF22)
+
+    if pWFHM.MixingOn:
+        # 32 with mixing: amplitude is the magnitude of the complex hlm
+        # before the (-1)^l and amp0 prefactors.
+        from ripplegw.waveforms.IMRPhenomXHM import IMRPhenomX_TimeShift_22
+        t0 = IMRPhenomX_TimeShift_22(pWF22)
+        # phifRef does not affect the magnitude.
+        hlm = _compute_32_hlm(freqs_geom, pWFHM, pWF22, t0, 0.0, 0.0)
+        amp_geom = np.abs(np.asarray(hlm))
+    else:
+        pAmp = xhm_get_amp_coefficients(pWFHM, pWF22)
+        amp_geom = np.asarray(xhm_amp_noModeMixing(freqs_geom, pAmp, pWFHM))
+
+    # Convert geometric amplitude to LAL's distance-and-mass units.
+    # LAL's SimIMRPhenomXHMAmplitude returns the *physical* amplitude in
+    # SI: Amp_lm = amp0 * Amp_geom_lm with amp0 = M^2 * MRSUN * MTSUN / d.
+    from ripplegw.constants import MTSUN, MRSUN, MPC
+    Mtot = params["m1"] + params["m2"]
+    amp0 = Mtot * MRSUN * Mtot * MTSUN / (params["distance_mpc"] * MPC)
+    return amp_geom * amp0
+
+
+@pytest.mark.parametrize("ell,m", NON_22_MODES, ids=[f"{l}{m}" for l, m in NON_22_MODES])
+def test_per_mode_amplitude_per_region(ell, m):
+    """Bisect amplitude error across inspiral/intermediate/ringdown."""
+    freqs_hz = make_freq_grid(f_min=20.0, f_max=512.0, df=0.125)
+    amp_ripple = _ripple_amp_only(freqs_hz, ell, m)
+    amp_lal = lal_xhm_amplitude(freqs_hz, ell, m)
+
+    rel = relative_amp_error(amp_ripple, amp_lal)
+    insp, inter, ring = region_masks(freqs_hz, ell, m)
+    tol = _TOL[(ell, m)]
+
+    failures = []
+    for name, mask, t in [
+        ("inspiral", insp, tol["inspiral"]),
+        ("intermediate", inter, tol["intermediate"]),
+        ("ringdown", ring, tol["ringdown"]),
+    ]:
+        if not np.any(mask):
+            continue
+        max_err = float(np.max(rel[mask]))
+        if max_err > t:
+            failures.append(f"({ell},{m}) {name}: {max_err:.3e} > {t:.0e}")
+
+    assert not failures, "\n".join(failures)

--- a/tests/cross_validation/test_lal_xhm_hphc.py
+++ b/tests/cross_validation/test_lal_xhm_hphc.py
@@ -1,0 +1,60 @@
+"""Layer 7: hp/hc spherical-harmonic assembly vs SimIMRPhenomXHM.
+
+By Layer 6 each (l,m) mode has been validated.  This test exercises
+the (-1)^l, Y_lm and 1/2*(F_neg ± F_pos) factors in
+`gen_IMRPhenomXHM_hphc`.  We sweep iota to flush conventions that
+collapse at face-on (iota=0).
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+
+from tests.cross_validation.xhm_helpers import (
+    LAL_AVAILABLE,
+    FIDUCIAL_PARAMS,
+    lal_xhm_full,
+    make_freq_grid,
+    ripple_xhm_hphc,
+)
+
+pytestmark = pytest.mark.skipif(
+    not LAL_AVAILABLE, reason="LALSuite required for cross-validation tests"
+)
+
+
+_INC_CASES = [0.0, np.pi / 4.0, np.pi / 2.0, 3.0 * np.pi / 4.0, np.pi]
+
+
+@pytest.mark.parametrize("inclination", _INC_CASES, ids=[f"inc{i:.2f}" for i in _INC_CASES])
+def test_xhm_hphc_strict(inclination):
+    params = dict(FIDUCIAL_PARAMS)
+    params["inclination"] = inclination
+
+    freqs_hz = make_freq_grid(f_min=20.0, f_max=512.0, df=0.125)
+
+    hp_r, hc_r = ripple_xhm_hphc(freqs_hz, params)
+    hp_l, hc_l = lal_xhm_full(freqs_hz, params)
+
+    # Trim to common length.
+    n = min(len(hp_r), len(hp_l))
+    hp_r, hc_r = hp_r[:n], hc_r[:n]
+    hp_l, hc_l = hp_l[:n], hc_l[:n]
+
+    nonzero = (np.abs(hp_l) + np.abs(hc_l)) > 0
+    if nonzero.sum() < 16:
+        pytest.skip("too few non-zero bins")
+
+    # Use the larger of |hp_l|, |hc_l| as denominator
+    scale = max(np.max(np.abs(hp_l)), np.max(np.abs(hc_l)))
+    hp_err = np.abs(hp_r[nonzero] - hp_l[nonzero]) / scale
+    hc_err = np.abs(hc_r[nonzero] - hc_l[nonzero]) / scale
+
+    max_hp = float(np.max(hp_err))
+    max_hc = float(np.max(hc_err))
+
+    assert max_hp < 1e-9, f"inc={inclination:.2f}: max |Δhp|/scale = {max_hp:.3e}"
+    assert max_hc < 1e-9, f"inc={inclination:.2f}: max |Δhc|/scale = {max_hc:.3e}"

--- a/tests/cross_validation/test_lal_xhm_mode_mixing.py
+++ b/tests/cross_validation/test_lal_xhm_mode_mixing.py
@@ -1,0 +1,72 @@
+"""Layer 6: 32-mode mixing isolation test.
+
+If Layer 5 fails for (3,2) but the other modes pass, the bug is inside
+`_compute_32_hlm` (spheroidal coefficients, mu mixing, or the s2s
+function).  We exercise the mixing across a small parameter grid where
+the mixing amplitude is large.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+
+from tests.cross_validation.xhm_helpers import (
+    LAL_AVAILABLE,
+    FIDUCIAL_PARAMS,
+    lal_xhm_one_mode_freqseq,
+    make_freq_grid,
+    relative_amp_error,
+    ripple_xhm_one_mode_complex,
+)
+
+pytestmark = pytest.mark.skipif(
+    not LAL_AVAILABLE, reason="LALSuite required for cross-validation tests"
+)
+
+
+# Mass ratio + spin combinations chosen to maximise mode-mixing strength:
+# - large mass ratio (q >= 4) makes the (3,2) mode a substantial fraction of (2,2)
+# - high aligned spin shifts QNM frequencies
+_MIXING_CASES = [
+    dict(m1=50.0, m2=10.0, chi1z=0.7,  chi2z=0.0),
+    dict(m1=50.0, m2=10.0, chi1z=-0.5, chi2z=0.2),
+    dict(m1=80.0, m2=20.0, chi1z=0.6,  chi2z=-0.3),
+    dict(m1=40.0, m2=15.0, chi1z=0.0,  chi2z=0.5),
+]
+
+
+@pytest.mark.parametrize(
+    "case", _MIXING_CASES, ids=[
+        f"q{int(c['m1']/c['m2'])}_s{c['chi1z']:+.1f}_{c['chi2z']:+.1f}" for c in _MIXING_CASES
+    ]
+)
+def test_32_mixing_complex_hlm(case):
+    params = dict(FIDUCIAL_PARAMS, **case)
+    freqs_hz = make_freq_grid(f_min=20.0, f_max=512.0, df=0.125)
+
+    h_ripple = ripple_xhm_one_mode_complex(freqs_hz, 3, 2, params)
+    h_lal = lal_xhm_one_mode_freqseq(freqs_hz, 3, 2, params)
+
+    nonzero = np.abs(h_lal) > 0
+    if nonzero.sum() < 16:
+        pytest.skip("too few non-zero LAL bins for (3,2)")
+
+    h_r = h_ripple[nonzero]
+    h_l = h_lal[nonzero]
+
+    max_amp_err = float(np.max(relative_amp_error(np.abs(h_r), np.abs(h_l))))
+    dphi = np.unwrap(np.angle(h_r) - np.angle(h_l))
+    dphi = dphi - dphi[0]
+    max_phase_err = float(np.max(np.abs(dphi)))
+
+    # Slightly looser than Layer 5 (3,2) because mode mixing amplifies
+    # any small QNM/coefficient errors.
+    assert max_amp_err < 1e-8, (
+        f"{case}: max relative amp err = {max_amp_err:.3e}"
+    )
+    assert max_phase_err < 1e-7, (
+        f"{case}: max abs phase err = {max_phase_err:.3e} rad"
+    )

--- a/tests/cross_validation/test_lal_xhm_one_mode.py
+++ b/tests/cross_validation/test_lal_xhm_one_mode.py
@@ -1,0 +1,79 @@
+"""Layer 5: per-mode complex hlm vs SimIMRPhenomXHMFrequencySequenceOneMode.
+
+Combines the amp + phase + t0 + phi0 + (-1)^l + amp0 prefactors that
+Layers 3 and 4 deliberately split apart.  Tests both phi_ref=0 and
+phi_ref=pi/3 to flush out the (mm/2)*phifRef + mm*phi0 reference-phase
+accounting that initial_plan.md §3 flagged.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+
+from tests.cross_validation.xhm_helpers import (
+    LAL_AVAILABLE,
+    FIDUCIAL_PARAMS,
+    XHM_MODES,
+    lal_xhm_one_mode_freqseq,
+    make_freq_grid,
+    relative_amp_error,
+    ripple_xhm_one_mode_complex,
+)
+
+pytestmark = pytest.mark.skipif(
+    not LAL_AVAILABLE, reason="LALSuite required for cross-validation tests"
+)
+
+
+# Combined per-mode tolerances (relative on amplitude, absolute on phase
+# in radians).  Tighter than per-region because we are at this layer
+# expecting all polynomial / fit errors already pinned at Layers 3-4.
+_TOL = {
+    (2, 2): dict(amp=1e-12, phase=1e-9),
+    (2, 1): dict(amp=5e-10, phase=5e-9),
+    (3, 3): dict(amp=5e-10, phase=5e-9),
+    (3, 2): dict(amp=1e-9,  phase=1e-8),
+    (4, 4): dict(amp=5e-10, phase=5e-9),
+}
+
+
+@pytest.mark.parametrize("phi_ref_label,phi_ref", [("phi0", 0.0), ("phi_pi3", np.pi / 3.0)])
+@pytest.mark.parametrize("ell,m", XHM_MODES, ids=[f"{l}{m}" for l, m in XHM_MODES])
+def test_per_mode_complex_hlm(ell, m, phi_ref_label, phi_ref):
+    params = dict(FIDUCIAL_PARAMS)
+    params["phi_ref"] = phi_ref
+
+    freqs_hz = make_freq_grid(f_min=20.0, f_max=512.0, df=0.125)
+
+    h_ripple = ripple_xhm_one_mode_complex(freqs_hz, ell, m, params)
+    h_lal = lal_xhm_one_mode_freqseq(freqs_hz, ell, m, params)
+
+    # Mask zero-amplitude bins (LAL zeros out beyond f_max_lm and below
+    # f_min_lm).  Compare only where LAL produced data.
+    nonzero = np.abs(h_lal) > 0
+    if nonzero.sum() < 16:
+        pytest.skip(f"({ell},{m}): too few non-zero LAL bins")
+
+    h_r = h_ripple[nonzero]
+    h_l = h_lal[nonzero]
+
+    # Relative amplitude error
+    amp_err = relative_amp_error(np.abs(h_r), np.abs(h_l))
+    max_amp_err = float(np.max(amp_err))
+
+    # Absolute phase error after subtracting the f_min value
+    # (constant offset is irrelevant for the mismatch).
+    dphi = np.unwrap(np.angle(h_r) - np.angle(h_l))
+    dphi = dphi - dphi[0]
+    max_phase_err = float(np.max(np.abs(dphi)))
+
+    tol = _TOL[(ell, m)]
+    assert max_amp_err < tol["amp"], (
+        f"({ell},{m}) {phi_ref_label}: max relative amp err = {max_amp_err:.3e} > {tol['amp']:.0e}"
+    )
+    assert max_phase_err < tol["phase"], (
+        f"({ell},{m}) {phi_ref_label}: max abs phase err = {max_phase_err:.3e} rad > {tol['phase']:.0e}"
+    )

--- a/tests/cross_validation/test_lal_xhm_phase.py
+++ b/tests/cross_validation/test_lal_xhm_phase.py
@@ -1,0 +1,118 @@
+"""Layer 4: per-mode phase vs lalsim.SimIMRPhenomXHMPhase.
+
+Both ripple and LAL define the per-mode phase up to a global additive
+constant; therefore we compare the phase *difference relative to the
+lowest-frequency bin*, not the absolute value.
+
+A linear-in-Mf mismatch (slope error) shows up as a non-zero residual
+after subtracting the value at f_min — this catches the
+DeltaT/t0 bug suspected in `initial_plan.md` §3.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tests.cross_validation.xhm_helpers import (
+    LAL_AVAILABLE,
+    FIDUCIAL_PARAMS,
+    NON_22_MODES,
+    lal_xhm_phase,
+    make_freq_grid,
+    region_masks,
+    ripple_pwf22,
+    unwrap_after_subtract,
+)
+
+from ripplegw.waveforms.IMRPhenomXHM import (
+    IMRPhenomX_TimeShift_22,
+    IMRPhenomXAS_Phase,
+    xhm_set_waveform_variables,
+    xhm_get_phase_coefficients,
+    xhm_phase_noModeMixing,
+    _compute_32_hlm,
+)
+
+pytestmark = pytest.mark.skipif(
+    not LAL_AVAILABLE, reason="LALSuite required for cross-validation tests"
+)
+
+
+# Per-region absolute phase tolerances (radians).  See debug_plan_xhm.md
+# for the calibration.
+_TOL_RAD = {
+    # (2,2) goes through XAS path (validated by IMRPhenomXAS tests).
+    (2, 1): dict(inspiral=5e-9, intermediate=5e-9, ringdown=5e-9),
+    (3, 3): dict(inspiral=5e-9, intermediate=5e-9, ringdown=5e-9),
+    (3, 2): dict(inspiral=1e-8, intermediate=1e-8, ringdown=1e-8),
+    (4, 4): dict(inspiral=5e-9, intermediate=5e-9, ringdown=5e-9),
+}
+
+
+def _ripple_phase_only(freqs_hz, ell, m, params=FIDUCIAL_PARAMS):
+    """Per-mode phase from ripple WITHOUT the (mm/2)*phifRef + mm*phi0
+    term — that lives in `XLALSimIMRPhenomXHMGethlmModes` and is
+    re-introduced at Layer 5.
+
+    This lets Layer 4 isolate the polynomial phase from the reference-
+    phase / time-shift assembly that Layer 5 tests.
+    """
+    pWF22 = ripple_pwf22(params)
+    M_s = pWF22["M_s"]
+    freqs_geom = jnp.array(freqs_hz) * M_s
+    pWFHM = xhm_set_waveform_variables(int(ell), int(m), pWF22)
+    t0 = IMRPhenomX_TimeShift_22(pWF22)
+
+    if ell == 2 and m == 2:
+        # 22 mode: ripple uses XAS phase + t0.
+        phase_22 = np.asarray(IMRPhenomXAS_Phase(jnp.array(freqs_hz), pWF22["theta"], pWF22["phase_coeffs"]))
+        phase = phase_22 + float(t0) * np.asarray(freqs_geom)
+        return phase
+
+    if pWFHM.MixingOn:
+        # Use angle of the complex hlm with phi_ref=0, phifRef set to 0
+        # so we subtract a constant only when comparing to LAL.
+        hlm = _compute_32_hlm(freqs_geom, pWFHM, pWF22, t0, 0.0, 0.0)
+        return np.unwrap(np.angle(np.asarray(hlm)))
+
+    pPhase = xhm_get_phase_coefficients(pWFHM, pWF22, t0)
+    phase = np.asarray(xhm_phase_noModeMixing(freqs_geom, pPhase, pWFHM, pWF22, t0))
+    return phase
+
+
+@pytest.mark.parametrize("ell,m", NON_22_MODES, ids=[f"{l}{m}" for l, m in NON_22_MODES])
+def test_per_mode_phase_per_region(ell, m):
+    freqs_hz = make_freq_grid(f_min=20.0, f_max=512.0, df=0.125)
+
+    phase_ripple = _ripple_phase_only(freqs_hz, ell, m)
+    phase_lal = lal_xhm_phase(freqs_hz, ell, m)
+
+    # Subtract the value at f_min — both phases are defined up to a
+    # global constant.  After subtraction, any *linear* residual
+    # indicates a t0/timeshift bug; any *nonlinear* residual indicates a
+    # polynomial fit bug.
+    diff = (phase_ripple - phase_ripple[0]) - (phase_lal - phase_lal[0])
+    diff = unwrap_after_subtract(diff)
+
+    insp, inter, ring = region_masks(freqs_hz, ell, m)
+    tol = _TOL_RAD[(ell, m)]
+
+    failures = []
+    for name, mask, t in [
+        ("inspiral", insp, tol["inspiral"]),
+        ("intermediate", inter, tol["intermediate"]),
+        ("ringdown", ring, tol["ringdown"]),
+    ]:
+        if not np.any(mask):
+            continue
+        max_err = float(np.max(np.abs(diff[mask])))
+        if max_err > t:
+            failures.append(
+                f"({ell},{m}) {name}: max|Δφ - linear_offset| = {max_err:.3e} rad > {t:.0e}"
+            )
+
+    assert not failures, "\n".join(failures)

--- a/tests/cross_validation/test_lal_xhm_setup.py
+++ b/tests/cross_validation/test_lal_xhm_setup.py
@@ -1,0 +1,97 @@
+"""Layer 1/2: pWF22 and per-mode QNM scalar invariants.
+
+The frequency-domain XHM amplitude is dominated by the inspiral
+``f^{-7/6}`` tail, so the *peak* of |Amp_lm(f)| usually sits at the
+lowest frequency, not at fRING.  Instead we sanity-check that ripple's
+fRING_lm sits inside the band where LAL's amplitude has a *local*
+ringdown bump — i.e. where the second derivative of log|Amp| changes
+sign.  This catches gross errors in QNM polynomial coefficients or
+``afinal``/``finmass`` computation without depending on the (small)
+ringdown bump being a global maximum.
+
+Layer 3 (per-mode amplitude shape) is the strict downstream test for
+QNM-frequency correctness.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+
+from tests.cross_validation.xhm_helpers import (
+    LAL_AVAILABLE,
+    FIDUCIAL_PARAMS,
+    XHM_MODES,
+    lal_xhm_amplitude,
+    make_freq_grid,
+    require_lal,
+    ripple_pwf22,
+)
+from ripplegw.waveforms.IMRPhenomXHM import xhm_set_waveform_variables
+
+pytestmark = pytest.mark.skipif(
+    not LAL_AVAILABLE, reason="LALSuite required for cross-validation tests"
+)
+
+
+def _ripple_fring_fdamp_hz(ell, m):
+    """Return (fRING_lm, fDAMP_lm) in Hz for the fiducial XHM binary.
+
+    The 22-mode QNM frequencies live in pWF22 directly; higher modes
+    use the per-mode XHMWaveformStruct.
+    """
+    pWF22 = ripple_pwf22(FIDUCIAL_PARAMS)
+    M_s = pWF22["M_s"]
+    if (ell, m) == (2, 2):
+        return float(pWF22["fRING22"]) / M_s, float(pWF22["fDAMP22"]) / M_s
+    pWFHM = xhm_set_waveform_variables(ell, m, pWF22)
+    return float(pWFHM.fRING) / M_s, float(pWFHM.fDAMP) / M_s
+
+
+@pytest.mark.parametrize("ell,m", XHM_MODES, ids=[f"{l}{m}" for l, m in XHM_MODES])
+def test_per_mode_fring_inside_band(ell, m):
+    """Sanity-check that ripple's per-mode fRING is positive, finite,
+    and falls inside a physically reasonable band (10 Hz – 2 kHz for
+    BBH-mass systems).  A wrong QNM polynomial typically pushes fRING
+    far outside this band.
+    """
+    require_lal()
+    fRING_Hz, fDAMP_Hz = _ripple_fring_fdamp_hz(ell, m)
+    assert np.isfinite(fRING_Hz) and np.isfinite(fDAMP_Hz)
+    assert 10.0 < fRING_Hz < 2000.0, f"({ell},{m}) fRING={fRING_Hz} Hz out of band"
+    assert 0.0 < fDAMP_Hz < fRING_Hz, f"({ell},{m}) fDAMP={fDAMP_Hz} Hz invalid"
+
+
+@pytest.mark.parametrize("ell,m", XHM_MODES, ids=[f"{l}{m}" for l, m in XHM_MODES])
+def test_lal_amp_finite_at_fring(ell, m):
+    """LAL's amplitude must be finite & non-zero at ripple's fRING_lm.
+
+    A grossly wrong fRING (e.g. above the model's f_max=0.3*M_inv) would
+    cause LAL to return 0 there.  This is a fast cheap probe before the
+    full Layer 3 amplitude comparison runs.
+    """
+    require_lal()
+    fRING_Hz, _ = _ripple_fring_fdamp_hz(ell, m)
+
+    # 21-bin window around fRING
+    df = 0.5
+    grid = fRING_Hz + df * np.arange(-10, 11)
+    grid = grid[grid > 0]
+    amp = lal_xhm_amplitude(grid, ell, m)
+
+    assert np.all(np.isfinite(amp)), f"({ell},{m}) non-finite LAL amp near fRING"
+    assert np.max(amp) > 0, f"({ell},{m}) LAL amp zero across fRING window"
+
+
+def test_pwf22_eta_delta_consistent():
+    """Sanity: eta and delta agree analytically — guards against
+    accidental sign flips when m1/m2 are perturbed.
+    """
+    pWF22 = ripple_pwf22(FIDUCIAL_PARAMS)
+    p = FIDUCIAL_PARAMS
+    eta_expected = p["m1"] * p["m2"] / (p["m1"] + p["m2"]) ** 2
+    delta_expected = abs(p["m1"] - p["m2"]) / (p["m1"] + p["m2"])
+    assert abs(float(pWF22["eta"]) - eta_expected) < 1e-12
+    assert abs(float(pWF22["delta"]) - delta_expected) < 1e-12

--- a/tests/cross_validation/test_lal_xphm_hphc.py
+++ b/tests/cross_validation/test_lal_xphm_hphc.py
@@ -1,0 +1,71 @@
+"""Layer 9: XPHM hp/hc strict comparison vs SimIMRPhenomXPHM.
+
+The existing `test_lal_mismatch.py::IMRPhenomXPHM` is the *final*
+correctness criterion (phase-maximised mismatch ≤ 1e-6 over 10 random
+samples).  This test instead does a *strict* per-bin hp/hc comparison
+on a single fiducial precessing binary, to expose the *shape* of any
+remaining discrepancy when the mismatch test fails.
+
+We test PrecVersion=222 (raises on MSA-init failure) — same setting
+the mismatch test uses.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import numpy as np
+import pytest
+
+from tests.cross_validation.xhm_helpers import (
+    LAL_AVAILABLE,
+    FIDUCIAL_PARAMS_PREC,
+    lal_xphm_full,
+    make_freq_grid,
+    ripple_xphm_hphc,
+)
+
+pytestmark = pytest.mark.skipif(
+    not LAL_AVAILABLE, reason="LALSuite required for cross-validation tests"
+)
+
+
+def _strict_xphm(inclination):
+    params = dict(FIDUCIAL_PARAMS_PREC)
+    params["inclination"] = inclination
+
+    freqs_hz = make_freq_grid(f_min=20.0, f_max=512.0, df=0.125)
+
+    try:
+        hp_l, hc_l = lal_xphm_full(freqs_hz, params)
+    except RuntimeError as e:
+        pytest.skip(f"LAL XPHM raised (likely MSA init): {e}")
+
+    hp_r, hc_r = ripple_xphm_hphc(freqs_hz, params)
+
+    n = min(len(hp_r), len(hp_l))
+    hp_r, hc_r = hp_r[:n], hc_r[:n]
+    hp_l, hc_l = hp_l[:n], hc_l[:n]
+
+    nonzero = (np.abs(hp_l) + np.abs(hc_l)) > 0
+    if nonzero.sum() < 16:
+        pytest.skip("too few non-zero bins")
+
+    scale = max(np.max(np.abs(hp_l)), np.max(np.abs(hc_l)))
+    return (
+        float(np.max(np.abs(hp_r[nonzero] - hp_l[nonzero])) / scale),
+        float(np.max(np.abs(hc_r[nonzero] - hc_l[nonzero])) / scale),
+    )
+
+
+@pytest.mark.parametrize(
+    "inclination", [0.0, np.pi / 4.0, np.pi / 2.0, 3.0 * np.pi / 4.0],
+    ids=lambda i: f"inc{i:.2f}",
+)
+def test_xphm_hphc_strict(inclination):
+    max_hp, max_hc = _strict_xphm(inclination)
+    # Looser than XHM because precession adds an MSA integration whose
+    # numeric path differs slightly between JAX and LAL.  Tighten when
+    # XPHM mismatch starts passing 1e-6.
+    assert max_hp < 1e-6, f"inc={inclination:.2f}: max |Δhp|/scale = {max_hp:.3e}"
+    assert max_hc < 1e-6, f"inc={inclination:.2f}: max |Δhc|/scale = {max_hc:.3e}"

--- a/tests/cross_validation/xhm_helpers.py
+++ b/tests/cross_validation/xhm_helpers.py
@@ -1,0 +1,418 @@
+"""Shared helpers for the XHM / XPHM bisection tests.
+
+These tests follow the pyramid in `debug_plan_xhm.md`:
+each layer compares ripple to LAL at a progressively higher level of
+abstraction (per-mode amplitude → phase → complex hlm → hp/hc).
+
+All helpers raise ``pytest.skip(...)`` when LALSuite is unavailable so
+the suite runs cleanly in environments that do not have lalsimulation
+installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+try:
+    import lal
+    import lalsimulation as lalsim
+
+    LAL_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    LAL_AVAILABLE = False
+
+
+# Fiducial BBH parameters used for deterministic per-mode comparisons.
+# Chosen to exercise: aligned spins of opposite sign, q != 1 (so odd-l modes
+# have non-zero amplitude), and total mass that places fRD inside the
+# default 20 Hz – 1024 Hz analysis band.
+FIDUCIAL_PARAMS = dict(
+    m1=36.0,    # solar masses
+    m2=29.0,
+    chi1z=0.30,
+    chi2z=-0.10,
+    distance_mpc=400.0,
+    f_ref=20.0,
+    inclination=0.4,  # rad
+    phi_ref=0.0,      # rad
+)
+
+# Fiducial precessing parameters (for XPHM tests).
+FIDUCIAL_PARAMS_PREC = dict(
+    m1=36.0,
+    m2=29.0,
+    chi1x=0.10,
+    chi1y=0.05,
+    chi1z=0.30,
+    chi2x=-0.05,
+    chi2y=0.07,
+    chi2z=-0.10,
+    distance_mpc=400.0,
+    f_ref=20.0,
+    inclination=0.4,
+    phi_ref=0.0,
+)
+
+XHM_MODES = [(2, 2), (2, 1), (3, 3), (3, 2), (4, 4)]
+NON_22_MODES = [(2, 1), (3, 3), (3, 2), (4, 4)]
+
+
+def require_lal():
+    if not LAL_AVAILABLE:
+        pytest.skip("LALSuite not available")
+
+
+def make_freq_grid(f_min: float = 20.0, f_max: float = 512.0, df: float = 1.0 / 8.0):
+    """Common Hz frequency grid for per-mode comparison tests.
+
+    Uses df = 1/8 Hz (T = 8 s segment) which matches the BBH grid used
+    elsewhere in the suite while keeping per-test cost low.
+    """
+    n = int(np.floor((f_max - f_min) / df)) + 1
+    return f_min + df * np.arange(n)
+
+
+def freqs_to_real8seq(freqs_hz: np.ndarray):
+    """Wrap a numpy frequency array as a lal.REAL8Sequence."""
+    require_lal()
+    seq = lal.CreateREAL8Sequence(len(freqs_hz))
+    seq.data[:] = np.asarray(freqs_hz, dtype=np.float64)
+    return seq
+
+
+def make_xhm_params_dict():
+    """Build a minimal LALDict for XHM mode-array tests.
+
+    We DO NOT activate a mode array here — the per-mode LAL functions
+    (SimIMRPhenomXHMAmplitude, SimIMRPhenomXHMPhase, ...) request a
+    specific (ell, m) directly and ignore the dict mode array.
+    """
+    require_lal()
+    return lal.CreateDict()
+
+
+def lal_xhm_amplitude(freqs_hz, ell, m, params=FIDUCIAL_PARAMS):
+    """Call lalsim.SimIMRPhenomXHMAmplitude on the given Hz grid.
+
+    Returns the amplitude array (REAL8Sequence as numpy array).
+    """
+    require_lal()
+    p = params
+    seq_in = freqs_to_real8seq(freqs_hz)
+    out = lalsim.SimIMRPhenomXHMAmplitude(
+        seq_in,
+        int(ell),
+        int(m),
+        p["m1"] * lal.MSUN_SI,
+        p["m2"] * lal.MSUN_SI,
+        0.0, 0.0, p["chi1z"],
+        0.0, 0.0, p["chi2z"],
+        p["distance_mpc"] * 1e6 * lal.PC_SI,
+        p["phi_ref"],
+        p["f_ref"],
+        make_xhm_params_dict(),
+    )
+    # `out` is a REAL8Sequence. Older swig wrappers return it directly;
+    # some versions return (status, out).
+    if isinstance(out, tuple):
+        out = out[-1]
+    return np.asarray(out.data, dtype=np.float64).copy()
+
+
+def lal_xhm_phase(freqs_hz, ell, m, params=FIDUCIAL_PARAMS):
+    """Call lalsim.SimIMRPhenomXHMPhase on the given Hz grid."""
+    require_lal()
+    p = params
+    seq_in = freqs_to_real8seq(freqs_hz)
+    out = lalsim.SimIMRPhenomXHMPhase(
+        seq_in,
+        int(ell),
+        int(m),
+        p["m1"] * lal.MSUN_SI,
+        p["m2"] * lal.MSUN_SI,
+        0.0, 0.0, p["chi1z"],
+        0.0, 0.0, p["chi2z"],
+        p["distance_mpc"] * 1e6 * lal.PC_SI,
+        p["phi_ref"],
+        p["f_ref"],
+        make_xhm_params_dict(),
+    )
+    if isinstance(out, tuple):
+        out = out[-1]
+    return np.asarray(out.data, dtype=np.float64).copy()
+
+
+def lal_xhm_one_mode_freqseq(freqs_hz, ell, m, params=FIDUCIAL_PARAMS):
+    """Call lalsim.SimIMRPhenomXHMFrequencySequenceOneMode.
+
+    Returns the complex h_{l,-m}(f) on the input grid.
+    """
+    require_lal()
+    p = params
+    seq_in = freqs_to_real8seq(freqs_hz)
+    out = lalsim.SimIMRPhenomXHMFrequencySequenceOneMode(
+        seq_in,
+        p["m1"] * lal.MSUN_SI,
+        p["m2"] * lal.MSUN_SI,
+        p["chi1z"],
+        p["chi2z"],
+        int(ell),
+        int(m),
+        p["distance_mpc"] * 1e6 * lal.PC_SI,
+        p["phi_ref"],
+        p["f_ref"],
+        make_xhm_params_dict(),
+    )
+    if isinstance(out, tuple):
+        out = out[-1]
+    return np.asarray(out.data.data, dtype=np.complex128).copy()
+
+
+def lal_xhm_full(freqs_hz, params=FIDUCIAL_PARAMS):
+    """Call lalsim.SimIMRPhenomXHM (hp, hc) on a uniform grid in Hz.
+
+    The LAL API requires (f_min, f_max, deltaF), so the input grid must
+    be uniform.  The returned arrays are masked to the input grid range.
+    """
+    require_lal()
+    p = params
+    df = float(freqs_hz[1] - freqs_hz[0])
+    f_min = float(freqs_hz[0])
+    f_max = float(freqs_hz[-1])
+    hp, hc = lalsim.SimIMRPhenomXHM(
+        p["m1"] * lal.MSUN_SI,
+        p["m2"] * lal.MSUN_SI,
+        p["chi1z"],
+        p["chi2z"],
+        f_min,
+        f_max,
+        df,
+        p["distance_mpc"] * 1e6 * lal.PC_SI,
+        p["inclination"],
+        p["phi_ref"],
+        p["f_ref"],
+        make_xhm_params_dict(),
+    )
+    n = len(hp.data.data)
+    freqs_lal = np.arange(n) * df
+    mask = (freqs_lal >= f_min - 0.5 * df) & (freqs_lal <= f_max + 0.5 * df)
+    return np.asarray(hp.data.data[mask]), np.asarray(hc.data.data[mask])
+
+
+def lal_xphm_one_mode_freqseq(freqs_hz, ell, m, params=FIDUCIAL_PARAMS_PREC):
+    """Call SimIMRPhenomXPHMFrequencySequenceOneMode -> (h^J pos, h^J neg).
+
+    Returns the positive-frequency J-frame strain.
+    """
+    require_lal()
+    p = params
+    seq_in = freqs_to_real8seq(freqs_hz)
+    # mirror tests/utils.py XPHM construction (PrecVersion 222, MSA twist)
+    lalparams = lal.CreateDict()
+    ModeArray = lalsim.SimInspiralCreateModeArray()
+    for el, em in [(2, 1), (2, 2), (3, 2), (3, 3), (4, 4)]:
+        lalsim.SimInspiralModeArrayActivateMode(ModeArray, el, em)
+    lalsim.SimInspiralWaveformParamsInsertModeArray(lalparams, ModeArray)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPHMTwistPhenomHM(lalparams, 1)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPHMMBandVersion(lalparams, 0)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPHMThresholdMband(lalparams, 0.0)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPrecVersion(lalparams, 222)
+
+    hpos, hneg = lalsim.SimIMRPhenomXPHMFrequencySequenceOneMode(
+        seq_in,
+        int(ell),
+        int(m),
+        p["m1"] * lal.MSUN_SI,
+        p["m2"] * lal.MSUN_SI,
+        p["chi1x"], p["chi1y"], p["chi1z"],
+        p["chi2x"], p["chi2y"], p["chi2z"],
+        p["distance_mpc"] * 1e6 * lal.PC_SI,
+        p["inclination"],
+        p["phi_ref"],
+        p["f_ref"],
+        lalparams,
+    )
+    return (
+        np.asarray(hpos.data.data, dtype=np.complex128).copy(),
+        np.asarray(hneg.data.data, dtype=np.complex128).copy(),
+    )
+
+
+def lal_xphm_full(freqs_hz, params=FIDUCIAL_PARAMS_PREC):
+    """Call lalsim.SimIMRPhenomXPHM on a uniform Hz grid (PrecVersion=222)."""
+    require_lal()
+    p = params
+    df = float(freqs_hz[1] - freqs_hz[0])
+    f_min = float(freqs_hz[0])
+    f_max = float(freqs_hz[-1])
+    lalparams = lal.CreateDict()
+    ModeArray = lalsim.SimInspiralCreateModeArray()
+    for el, em in [(2, 1), (2, 2), (3, 2), (3, 3), (4, 4)]:
+        lalsim.SimInspiralModeArrayActivateMode(ModeArray, el, em)
+    lalsim.SimInspiralWaveformParamsInsertModeArray(lalparams, ModeArray)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPHMTwistPhenomHM(lalparams, 1)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPHMMBandVersion(lalparams, 0)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPHMThresholdMband(lalparams, 0.0)
+    lalsim.SimInspiralWaveformParamsInsertPhenomXPrecVersion(lalparams, 222)
+
+    hp, hc = lalsim.SimIMRPhenomXPHM(
+        p["m1"] * lal.MSUN_SI,
+        p["m2"] * lal.MSUN_SI,
+        p["chi1x"], p["chi1y"], p["chi1z"],
+        p["chi2x"], p["chi2y"], p["chi2z"],
+        p["distance_mpc"] * 1e6 * lal.PC_SI,
+        p["inclination"],
+        p["phi_ref"],
+        f_min, f_max, df,
+        p["f_ref"],
+        lalparams,
+    )
+    n = len(hp.data.data)
+    freqs_lal = np.arange(n) * df
+    mask = (freqs_lal >= f_min - 0.5 * df) & (freqs_lal <= f_max + 0.5 * df)
+    return np.asarray(hp.data.data[mask]), np.asarray(hc.data.data[mask])
+
+
+# ---------------------------------------------------------------------------
+# Ripple-side helpers
+# ---------------------------------------------------------------------------
+
+
+def ripple_pwf22(params=FIDUCIAL_PARAMS):
+    """Return (pWF22, freqs_geom_factor M_s) for the fiducial parameters."""
+    from ripplegw.waveforms.IMRPhenomXHM import build_pWF22
+    pWF22 = build_pWF22(
+        params["m1"], params["m2"], params["chi1z"], params["chi2z"], params["f_ref"]
+    )
+    return pWF22
+
+
+def ripple_xhm_one_mode_complex(freqs_hz, ell, m, params=FIDUCIAL_PARAMS):
+    """Return ripple's complex h_{l,m} on the given Hz grid.
+
+    Includes the same overall amp0 distance prefactor and (-1)^l sign that
+    LAL's SimIMRPhenomXHMFrequencySequenceOneMode applies, so the result
+    is directly comparable to LAL.
+    """
+    import jax.numpy as jnp
+    from ripplegw.waveforms.IMRPhenomXHM import (
+        XLALSimIMRPhenomXHMGethlmModes, build_pWF22,
+    )
+    from ripplegw.constants import MTSUN, MRSUN, MPC
+
+    Mtot = params["m1"] + params["m2"]
+    M_s = Mtot * MTSUN
+    dist_m = params["distance_mpc"] * MPC
+    amp0 = Mtot * MRSUN * Mtot * MTSUN / dist_m
+    minus1l = 1 if ell % 2 == 0 else -1
+
+    freqs_geom = jnp.array(freqs_hz) * M_s
+    pWF22 = build_pWF22(
+        params["m1"], params["m2"], params["chi1z"], params["chi2z"], params["f_ref"]
+    )
+    hlm_dict = XLALSimIMRPhenomXHMGethlmModes(
+        freqs_geom, pWF22, params["phi_ref"], [(int(ell), int(m))]
+    )
+    return np.asarray(hlm_dict[(int(ell), int(m))]) * amp0 * minus1l
+
+
+def ripple_xhm_hphc(freqs_hz, params=FIDUCIAL_PARAMS):
+    """Return ripple's hp, hc for the fiducial XHM parameters on a Hz grid."""
+    import jax.numpy as jnp
+    from ripplegw.waveforms.IMRPhenomXHM import gen_IMRPhenomXHM_hphc
+
+    theta = jnp.array([
+        params["m1"], params["m2"], params["chi1z"], params["chi2z"],
+        params["distance_mpc"], 0.0, params["phi_ref"], params["inclination"],
+    ])
+    hp, hc = gen_IMRPhenomXHM_hphc(jnp.array(freqs_hz), theta, params["f_ref"])
+    return np.asarray(hp), np.asarray(hc)
+
+
+def ripple_xphm_hphc(freqs_hz, params=FIDUCIAL_PARAMS_PREC):
+    """Return ripple's hp, hc for fiducial XPHM parameters on a Hz grid."""
+    import jax.numpy as jnp
+    from ripplegw.waveforms.IMRPhenomXPHM import generate_xphm
+
+    hp, hc = generate_xphm(
+        params["m1"], params["m2"],
+        params["chi1x"], params["chi1y"], params["chi1z"],
+        params["chi2x"], params["chi2y"], params["chi2z"],
+        params["distance_mpc"], params["inclination"], params["phi_ref"],
+        jnp.array(freqs_hz), params["f_ref"],
+    )
+    return np.asarray(hp), np.asarray(hc)
+
+
+# ---------------------------------------------------------------------------
+# Region masks
+# ---------------------------------------------------------------------------
+
+
+def region_masks(freqs_hz, ell, m, params=FIDUCIAL_PARAMS):
+    """Return boolean masks (inspiral, intermediate, ringdown) for one mode.
+
+    The boundary frequencies (fAmpMatchIN/IM, fPhaseMatchIN/IM) are stored
+    inside ripple's per-mode pPhase/pAmp objects; we use the *amplitude*
+    boundaries as a coarse proxy that works well enough to bisect.
+    """
+    from ripplegw.waveforms.IMRPhenomXHM import (
+        build_pWF22, xhm_set_waveform_variables, xhm_get_amp_coefficients,
+    )
+    pWF22 = build_pWF22(
+        params["m1"], params["m2"], params["chi1z"], params["chi2z"], params["f_ref"]
+    )
+    pWFHM = xhm_set_waveform_variables(int(ell), int(m), pWF22)
+    pAmp = xhm_get_amp_coefficients(pWFHM, pWF22)
+    M_s = pWF22["M_s"]
+    fIn_Hz = float(pAmp.fAmpMatchIN) / M_s
+    fIm_Hz = float(pAmp.fAmpMatchIM) / M_s
+    f = np.asarray(freqs_hz)
+    return (f < fIn_Hz), ((f >= fIn_Hz) & (f < fIm_Hz)), (f >= fIm_Hz)
+
+
+# ---------------------------------------------------------------------------
+# Comparison utilities
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RegionStats:
+    name: str
+    n: int
+    max_abs: float
+    max_rel: float
+
+
+def per_region_max_abs(values, masks, names=("inspiral", "intermediate", "ringdown")):
+    """Return per-region max(|values|) for a real array."""
+    out = []
+    v = np.asarray(values)
+    for nm, mask in zip(names, masks):
+        if not np.any(mask):
+            out.append(RegionStats(nm, 0, 0.0, 0.0))
+            continue
+        sel = v[mask]
+        out.append(RegionStats(nm, int(mask.sum()), float(np.max(np.abs(sel))), 0.0))
+    return out
+
+
+def relative_amp_error(amp_ripple, amp_lal):
+    """|amp_r - amp_l| / max(|amp_l|).
+
+    Use a global denominator (max amplitude in the band) so a single
+    bin near a zero crossing does not dominate the metric.
+    """
+    a_r = np.asarray(amp_ripple)
+    a_l = np.asarray(amp_lal)
+    denom = np.max(np.abs(a_l)) if np.max(np.abs(a_l)) > 0 else 1.0
+    return np.abs(a_r - a_l) / denom
+
+
+def unwrap_after_subtract(phase_diff):
+    """Unwrap a 2*pi-ambiguous phase difference."""
+    return np.unwrap(np.asarray(phase_diff))

--- a/uv.lock
+++ b/uv.lock
@@ -954,14 +954,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5c/f3aedc83549aae71cd52b9e9687fe896e3dc6e966ba20eba04718605d198/markdown_it_py-4.1.0.tar.gz", hash = "sha256:760e3f87b2787c044c5138a5ba107b7c2be26c03b13cc7f8fe42756b65b1df6c", size = 81613, upload-time = "2026-05-06T16:32:13.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/88/802c82060c54bc7dde21eb0033e337838b8181a1323254aa9ec41cbfc3d1/markdown_it_py-4.1.0-py3-none-any.whl", hash = "sha256:d4939a62a2dd0cd9cb80a191a711ba1d39bac8ed5ef9e9966895b0171c01c46d", size = 90955, upload-time = "2026-05-06T16:32:12.184Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fix the remaining `IMRPhenomXPHM` and `IMRPhenomXHM` mismatches against LALSuite on the repo's current validation path.

This PR closes the large `IMRPhenomXPHM` disagreement, fixes the remaining extreme-parameter `IMRPhenomXHM` tail, and removes the last false strict XPHM residual caused by pytest/JAX bootstrap precision.

## Root causes

### IMRPhenomXPHM

There were two real XPHM issues and one test/bootstrap issue:

1. `IMRPhenomXPHM` was not matching the repo's LAL validation branch.
   - The tests validate against `TwistPhenomHM=1`, which twists up the legacy aligned-spin `IMRPhenomHM` seed rather than the default XHM seed.
   - Ripple was still building the XPHM path from the XHM-style seed.

2. Ripple's MSA initializer did not match LAL's default expansion-order truncation semantics.
   - LAL computes the higher-order `Omegaz*` / `Omegazeta*` chain and then zeros the 5th-order correction coefficients for the default `PhenomXPExpansionOrder=5` before initializing `phiz_0` / `zeta_0`.
   - Ripple was retaining those terms, which shifted the cached MSA constants and the twist-up angles.

3. The final strict residual under pytest was not a waveform bug.
   - `tests.conftest` imported shared JAX helpers before x64 was enabled, so pytest exercised some paths at degraded precision.

### IMRPhenomXHM

Two XHM issues mattered on the repo's validation path:

1. `chiPNHat` in `build_pWF22()` did not match LAL's denominator.
   - The ripple implementation missed the `(1 - 76 * eta / 113)` normalization used by `XLALSimIMRPhenomXchiPNHat`.

2. Ripple was missing a LAL-specific high-spin `(2,1)` phase safeguard.
   - In `IMRPhenomXHM_GetPhaseCoefficients`, LAL rewrites the first two intermediate phase-derivative collocation values for `(2,1)` when `STotR >= 0.8`, using finite differences of the full 22-mode phase derivative before selecting the 5/6 collocation subset.
   - Ripple had ported the special collocation-index selection for this corner, but not the preceding collocation-value rewrite, which left the extreme aligned-spin tail in the large `n=200` sweep.

## What changed

### Waveform fixes

- `src/ripplegw/waveforms/IMRPhenomXPHM.py`
  - switch `generate_xphm()` to the legacy `IMRPhenomHM` coprecessing seed so ripple matches the repo's `TwistPhenomHM=1` LAL validation branch

- `src/ripplegw/waveforms/initialize_MSA_system.py`
  - add `expansion_order=5`
  - restore the full raw 5th-order `Omegaz` / `Omegazeta` chain
  - zero the higher-order correction coefficients exactly as LAL does for the selected expansion order before `phiz_0` / `zeta_0` initialization

- `src/ripplegw/waveforms/IMRPhenomXHM.py`
  - correct `chiPNHat` in `build_pWF22()` to match LAL
  - port the missing high-spin `(2,1)` intermediate-phase collocation-value rewrite used by LAL before the collocation subset solve

### Test/bootstrap fix

- `tests/conftest.py`
  - enable `jax_enable_x64=True` before importing shared JAX test utilities
  - remove the final false XPHM strict residual seen only under pytest

### Comparison tooling

- [`scripts/compare_baseline_xhm_xphm_mismatch.py`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/baseline_xhm_xphm_mismatch.py)
  - compare baseline-format runs (`pre_fix`, `post_fix`, etc.) and generate before/after figures plus summary JSON

- [`scripts/compare_baseline_to_current_csv.py`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/compare_baseline_to_current_csv.py)
  - compare saved baseline artifacts or CSV-vs-CSV sweep results from `tests/cross_validation/results/<run_tag>/`
  - extended to support direct `pre_fix_n200_T32` vs `n200_T32` comparison for a true `200 vs 200` pre/post figure set

## Validation

- `uv run --group cross-validation python -m pytest tests/cross_validation/test_lal_mismatch.py -k IMRPhenomXPHM --n-samples 200 --T 32 -q`
- `uv run --group cross-validation python -m pytest tests/cross_validation/test_lal_xphm_hphc.py -q`
- `uv run --group cross-validation python -m pytest tests/cross_validation/test_lal_mismatch.py -k IMRPhenomXHM --n-samples 200 --T 32 -q`
- regenerate comparison artifacts from:
  - pre-fix `n=200` CSVs at `tests/cross_validation/results/pre_fix_n200_T32/`
  - post-fix `n=200` CSVs at `tests/cross_validation/results/n200_T32/`

## Results

### Large-sweep `200 vs 200` comparison

| Waveform | Pre-fix testable | Pre-fix failed | Pre-fix max mismatch | Post-fix testable | Post-fix failed | Post-fix max mismatch |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `IMRPhenomXHM` | 200 | 152 | `4.6887e-04` | 200 | 0 | `2.4188e-07` |
| `IMRPhenomXPHM` | 199 | 199 | `9.8761e-01` | 199 | 0 | `1.0016e-10` |

### Representative XHM outlier reduction

- previous worst `IMRPhenomXHM` outlier: `~1.1236e-05`
- after the high-spin `(2,1)` collocation fix: `~1.1307e-07`

## Artifacts

- Pre-fix `n=200` CSVs:
  - [`pre_fix_n200_T32/mismatch_IMRPhenomXHM.csv`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/artifacts/pre_fix_n200_T32/mismatch_IMRPhenomXHM.csv)
  - [`pre_fix_n200_T32/mismatch_IMRPhenomXPHM.csv`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/artifacts/pre_fix_n200_T32/mismatch_IMRPhenomXPHM.csv)

- Post-fix `n=200` CSVs:
  - [`n200_T32/mismatch_IMRPhenomXHM.csv`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/artifacts/n200_T32/mismatch_IMRPhenomXHM.csv)
  - [`n200_T32/mismatch_IMRPhenomXPHM.csv`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/artifacts/n200_T32/mismatch_IMRPhenomXPHM.csv)

- `200 vs 200` comparison figures:
  - [`comparisons/pre_fix_n200_vs_post_fix_n200_csv/IMRPhenomXHM_comparison.png`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/artifacts/comparisons/pre_fix_n200_vs_post_fix_n200_csv/IMRPhenomXHM_comparison.png)
  - [`comparisons/pre_fix_n200_vs_post_fix_n200_csv/IMRPhenomXPHM_comparison.png`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/artifacts/comparisons/pre_fix_n200_vs_post_fix_n200_csv/IMRPhenomXPHM_comparison.png)
  - [`comparisons/pre_fix_n200_vs_post_fix_n200_csv/summary.json`](https://github.com/GW-JAX-Team/hackathon_fix_xphm/blob/main/xhm-xphm-debug/artifacts/comparisons/pre_fix_n200_vs_post_fix_n200_csv/summary.json)
  
  
<img width="1920" height="720" alt="IMRPhenomXHM_comparison" src="https://github.com/user-attachments/assets/8c599812-4b87-4790-8a39-3a44e5334b58" />
<img width="1920" height="720" alt="IMRPhenomXPHM_comparison" src="https://github.com/user-attachments/assets/9ce49579-bd32-4e4c-b95e-191f0a0eebb1" />


## Notes

- The remaining ultra-strict XHM layer tests still probe helper-level convention exactness beyond the large-sweep mismatch threshold; this PR is specifically about fixing the live mismatch bugs on the repo's current validation path.
- The final XPHM strict residual was a pytest/JAX precision bootstrap issue, not an additional waveform-physics mismatch.