### PR TITLE
BUG: fix `IMRPhenomXAS.PhaseDerivative` to work on frequency arrays

### DIFF
--- a/src/ripplegw/waveforms/IMRPhenomXAS.py
+++ b/src/ripplegw/waveforms/IMRPhenomXAS.py
@@ -882,26 +882,22 @@ def PhaseDerivative(
     _phi_Int_match_f2, dphi_Int_match_f2 = jax.value_and_grad(phi_Int_func)(f2_Ms)
     beta1 = dphi_Int_match_f2 - dphi_MRD_match_f2
 
-    dphi_Ins = jax.vmap(jax.grad(get_inspiral_phase), (0, None, None))(fM_s, theta, phase_coeffs)
+    dphi_Ins = jax.vmap(jax.grad(get_inspiral_phase), (0, None, None))(
+        fM_s, theta, phase_coeffs
+    )
     dphi_Int = jax.vmap(jax.grad(phi_Int_func))(fM_s)
     dphi_MRD = (
-        jax.vmap(jax.grad(
-            lambda x: get_mergerringdown_raw_phase(x, theta, phase_coeffs, chip)[0]
-        ))(fM_s)
+        jax.vmap(
+            jax.grad(
+                lambda x: get_mergerringdown_raw_phase(x, theta, phase_coeffs, chip)[0]
+            )
+        )(fM_s)
         + beta1
     )
 
     # Two-step conditional to determine correct stage of waveform, divide by eta only at the end
-    dphase_dMf = jnp.where(
-        fM_s < f1_Ms,
-        dphi_Ins,
-        dphi_Int
-    )
-    dphase_dMf = jnp.where(
-        fM_s < f2_Ms,
-        dphase_dMf / eta,
-        dphi_MRD / eta
-    )
+    dphase_dMf = jnp.where(fM_s < f1_Ms, dphi_Ins, dphi_Int)
+    dphase_dMf = jnp.where(fM_s < f2_Ms, dphase_dMf / eta, dphi_MRD / eta)
 
     return dphase_dMf * M_s
 

--- a/src/ripplegw/waveforms/IMRPhenomXAS.py
+++ b/src/ripplegw/waveforms/IMRPhenomXAS.py
@@ -835,6 +835,10 @@ def PhaseDerivative(
     as Phase(), but without differentiating through the final Heaviside assembly.
     """
 
+    # If f is a float cast it to an array of shape (1,) so vmap works properly down the line
+    if f.shape == ():
+        f = f.reshape((1,))
+
     m1, m2, chi1, chi2 = theta
     m1_s = m1 * MTSUN
     m2_s = m2 * MTSUN
@@ -878,26 +882,27 @@ def PhaseDerivative(
     _phi_Int_match_f2, dphi_Int_match_f2 = jax.value_and_grad(phi_Int_func)(f2_Ms)
     beta1 = dphi_Int_match_f2 - dphi_MRD_match_f2
 
-    dphi_Ins = jax.grad(get_inspiral_phase)(fM_s, theta, phase_coeffs)
-    dphi_Int = jax.grad(phi_Int_func)(fM_s)
+    dphi_Ins = jax.vmap(jax.grad(get_inspiral_phase), (0, None, None))(fM_s, theta, phase_coeffs)
+    dphi_Int = jax.vmap(jax.grad(phi_Int_func))(fM_s)
     dphi_MRD = (
-        jax.grad(
+        jax.vmap(jax.grad(
             lambda x: get_mergerringdown_raw_phase(x, theta, phase_coeffs, chip)[0]
-        )(fM_s)
+        ))(fM_s)
         + beta1
     )
 
-    dphase_dMf = jax.lax.cond(
+    # Two-step conditional to determine correct stage of waveform, divide by eta only at the end
+    dphase_dMf = jnp.where(
         fM_s < f1_Ms,
-        lambda _: dphi_Ins / eta,
-        lambda _: jax.lax.cond(
-            fM_s < f2_Ms,
-            lambda __: dphi_Int / eta,
-            lambda __: dphi_MRD / eta,
-            operand=None,
-        ),
-        operand=None,
+        dphi_Ins,
+        dphi_Int
     )
+    dphase_dMf = jnp.where(
+        fM_s < f2_Ms,
+        dphase_dMf / eta,
+        dphi_MRD / eta
+    )
+
     return dphase_dMf * M_s
 
 


### PR DESCRIPTION
This closes https://github.com/GW-JAX-Team/ripple/issues/132. 

Three changes are made so that this works on frequency arrays:
1) `vmap` the three grad calls
2) Cast input from float to array if necessary so vmap works
3) Use `where` instead of `lax.cond` to work with arrays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phase derivative calculations for scalar and array frequency inputs.
  * Ensured consistent results across inspiral, intermediate, and ringdown stages.
  * Improved compatibility with vectorised derivative evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->