### PR TITLE
fix(tests): stop comparing JAX/XLA arccos output to NumPy bit-for-bit

### DIFF
--- a/tests/unit/waveforms/cw/test_barycenter.py
+++ b/tests/unit/waveforms/cw/test_barycenter.py
@@ -1,5 +1,6 @@
 """Unit tests for CW barycentering geometry."""
 
+import jax.numpy as jnp
 import numpy as np
 
 from ripplegw.waveforms.cw.barycenter import C, _detector_geocentric, source_unit_vector
@@ -46,19 +47,24 @@ def test_detector_geocentric_is_unchanged_for_a_real_site():
 
     ``jnp.where(rd > 0, ...)`` engages only at exactly zero, so a real detector must reproduce
     the plain spherical conversion bit for bit -- otherwise the fix has moved existing signals.
+
+    The reference here is computed with ``jnp`` (not ``numpy``) so both sides run through the
+    same XLA backend: NumPy's libm and JAX/XLA's CPU transcendentals are each accurate but not
+    guaranteed bit-identical, so a NumPy reference can differ by 1 ULP depending on the host CPU
+    -- unrelated to whether the guard is inert.
     """
     location = (-2161414.93, -3834695.35, 4600350.23)  # LIGO Hanford, metres
     rd, longitude, latitude, sin_lat, cos_lat = _detector_geocentric(location)
 
-    lx, ly, lz = (np.asarray(c) / C for c in location)
-    expected_rd = np.sqrt(lx * lx + ly * ly + lz * lz)
-    expected_lat = np.pi / 2.0 - np.arccos(lz / expected_rd)
+    lx, ly, lz = (jnp.asarray(c) / C for c in location)
+    expected_rd = jnp.sqrt(lx * lx + ly * ly + lz * lz)
+    expected_lat = jnp.pi / 2.0 - jnp.arccos(lz / expected_rd)
 
     assert float(rd) == float(expected_rd)
-    assert float(longitude) == float(np.arctan2(ly, lx))
+    assert float(longitude) == float(jnp.arctan2(ly, lx))
     assert float(latitude) == float(expected_lat)
-    assert float(sin_lat) == float(np.sin(expected_lat))
-    assert float(cos_lat) == float(np.cos(expected_lat))
+    assert float(sin_lat) == float(jnp.sin(expected_lat))
+    assert float(cos_lat) == float(jnp.cos(expected_lat))
 
 
 def test_differentiating_at_the_geocentre_is_not_supported():

--- a/uv.lock
+++ b/uv.lock
@@ -2330,7 +2330,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.27.0"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -2338,9 +2338,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/78/fda3361b56efc27944f24225f6ecd13d96d6fcfe37bd0eb34e2f4c63f9fc/typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5", size = 203430, upload-time = "2026-07-15T19:21:07.007Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1", size = 122716, upload-time = "2026-07-15T19:21:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `test_detector_geocentric_is_unchanged_for_a_real_site` asserted `float(latitude) == float(expected_lat)` where `expected_lat` was computed with NumPy while `latitude` comes from JAX/XLA. NumPy's libm and JAX/XLA's CPU transcendentals aren't guaranteed bit-identical, so the comparison could differ by 1 ULP depending on the host CPU's code path.
- Observed failing on the `v0.3.1` release CI and the #143 PR CI (Linux, Python 3.11/3.12), while passing locally (macOS) and on the 3.13 CI job for the same commit -- confirming it's a cross-backend rounding difference, not a real regression.
- Fix: build the "expected" reference with `jnp` instead of `numpy`, so both sides run through the same XLA backend and the comparison is deterministic, while still proving the geocentre guard (`jnp.where(rd > 0, ...)`) is a no-op for a real site.

## Test plan
- [x] `pytest tests/unit/waveforms/cw/test_barycenter.py -v` passes locally
- [ ] CI passes on Linux runners (3.11/3.12/3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated real-site barycentring test coverage to use JAX-compatible numerical reference calculations.
  * Improved validation across longitude, radius, latitude, and trigonometric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->