### PR TITLE
ci: open scheduled dev -> main PR via GitHub App token

### DIFF
--- a/.github/workflows/dev-to-main-pr.yml
+++ b/.github/workflows/dev-to-main-pr.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         if: steps.gate.outputs.run == 'true'
         with:
-          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          client-id: ${{ secrets.AUTOMATION_APP_ID }}  # secret holds the App's Client ID (Iv23...)
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           permission-pull-requests: write  # scope the token: this workflow only opens/updates PRs
 

--- a/.github/workflows/dev-to-main-pr.yml
+++ b/.github/workflows/dev-to-main-pr.yml
@@ -34,10 +34,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false  # only local git reads + gh (GH_TOKEN) are used
 
-      - name: Open PR from ripple-dev to main and request CodeRabbit review
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        if: steps.gate.outputs.run == 'true'
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
+      - name: Open or reuse the ripple-dev -> main PR
+        id: open_pr
         if: steps.gate.outputs.run == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}  # App token: PRs it opens trigger CI without manual approval
         run: |
           pr_url=$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head ripple-dev --state open --json url --jq '.[0].url // empty')
           if [ -z "$pr_url" ]; then
@@ -60,6 +68,15 @@ jobs:
               --body "Automated monthly pull request merging \`ripple-dev\` into \`main\`.")
           fi
 
-          gh pr comment "$pr_url" \
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Request CodeRabbit review
+        # CodeRabbit skips auto-review for bot-authored PRs, so ping it explicitly.
+        # Kept on GITHUB_TOKEN so the comment is posted as github-actions[bot].
+        if: steps.gate.outputs.run == 'true' && steps.open_pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ steps.open_pr.outputs.pr_url }}" \
             --repo "$GITHUB_REPOSITORY" \
             --body "@coderabbitai review"

--- a/.github/workflows/dev-to-main-pr.yml
+++ b/.github/workflows/dev-to-main-pr.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           app-id: ${{ secrets.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          permission-pull-requests: write  # scope the token: this workflow only opens/updates PRs
 
       - name: Open or reuse the ripple-dev -> main PR
         id: open_pr


### PR DESCRIPTION
## Problem

`dev-to-main-pr.yml` opens the monthly `ripple-dev → main` sync PR with
the built-in `GITHUB_TOKEN`. GitHub does not auto-run workflows for such
PRs, so the PR's CI run would wait for a manual **"Approve and run"** —
and the `main` ruleset's strict required status checks can't be met
until it does. The workflow has only ever been hand-driven so far; the
first real scheduled run is the last Thursday of this month.

## Fix

Mint a token from the **GW JAX Team Automation** GitHub App for
`gh pr create`, so the sync PR's CI runs on its own.

The `@coderabbitai review` ping moves to its own step and stays on
`GITHUB_TOKEN`. CodeRabbit skips auto-review for **every** bot-authored
PR (confirmed across `github-actions`, `pre-commit-ci`, and `dependabot`
PRs in these repos), so the explicit ping is still required — the App
token does not change that.

## Prerequisites (already in place)

Org secrets `AUTOMATION_APP_ID` and `AUTOMATION_APP_PRIVATE_KEY`, and the
App installed on this repo.

## Verify after merge

Run the workflow manually (`workflow_dispatch`) with `ripple-dev` ahead
of `main`; the opened PR's CI should start with no "Approve and run".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Scheduled pull request automation now uses the required authentication permissions to create or reuse pull requests.
  * The workflow identifies the relevant pull request and directs automated review comments to it.
  * Improved reliability and accuracy for scheduled pull request creation and review handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->